### PR TITLE
feat: add indexing of past builds

### DIFF
--- a/ci_server/server.py
+++ b/ci_server/server.py
@@ -4,6 +4,7 @@ from ci_server.logger import Logger
 from datetime import datetime
 from ci_server.ci_logic import continuous_integration 
 from multiprocessing import Process
+from flask_autoindex import AutoIndex
 
 log = Logger()
 
@@ -13,6 +14,11 @@ INTERNAL_ERROR = ("internal error", 500)
 
 app = Flask(__name__)
 app.config.from_prefixed_env(loads=lambda x: x)
+
+build_path = "./build_history" # Relative path to the build history directory
+
+# Show the files in the build history directory
+AutoIndex(app, browse_root=build_path) 
 
 assert app.config["AUTHKEY"], "No authkey in ENV"
 

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "docs"]
 strategy = ["cross_platform", "inherit_metadata"]
 lock_version = "4.4.1"
-content_hash = "sha256:c30cba0db4792de11c25ba019188f3e3a8d9957d604dba2569a0b250a844d778"
+content_hash = "sha256:4eb07351694ca44e6f5efb96fd4944a7ea1061d4bc10739e70d81d6576bb1f0c"
 
 [[package]]
 name = "alabaster"
@@ -194,6 +194,42 @@ dependencies = [
 files = [
     {file = "flask-3.0.2-py3-none-any.whl", hash = "sha256:3232e0e9c850d781933cf0207523d1ece087eb8d87b23777ae38456e2fbe7c6e"},
     {file = "flask-3.0.2.tar.gz", hash = "sha256:822c03f4b799204250a7ee84b1eddc40665395333973dfb9deebfe425fefcb7d"},
+]
+
+[[package]]
+name = "flask-autoindex"
+version = "0.6.6"
+summary = "The mod_autoindex for Flask"
+groups = ["default"]
+dependencies = [
+    "Flask-Silk>=0.2",
+    "Flask>=1.1",
+    "future>=0.13.0",
+]
+files = [
+    {file = "Flask-AutoIndex-0.6.6.tar.gz", hash = "sha256:ea319f7ccadf68ddf98d940002066278c779323644f9944b300066d50e2effc7"},
+]
+
+[[package]]
+name = "flask-silk"
+version = "0.2"
+summary = "Adds silk icons to your Flask application or blueprint, or extension."
+groups = ["default"]
+dependencies = [
+    "Flask>=0.8",
+]
+files = [
+    {file = "Flask-Silk-0.2.tar.gz", hash = "sha256:80a21faf09fe257443a4fbbf8cd3f6c793c567c87ff784751a1c38d2e18b5fbe"},
+]
+
+[[package]]
+name = "future"
+version = "0.18.3"
+requires_python = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
+summary = "Clean single-source support for Python 3 and 2"
+groups = ["default"]
+files = [
+    {file = "future-0.18.3.tar.gz", hash = "sha256:34a17436ed1e96697a86f9de3d15a3b0be01d8bc8de9c1dffd59fb8234ed5307"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ authors = [
 dependencies = [
     "flask>=3.0.2",
     "requests>=2.31.0",
+    "Flask-AutoIndex>=0.6.6",
 ]
 requires-python = ">=3.8"
 readme = "README.md"

--- a/test_ci_server/test_server.py
+++ b/test_ci_server/test_server.py
@@ -77,6 +77,20 @@ class TestServer(unittest.TestCase):
             response = client.get(self.index_addr)
             self.assertTrue(response.status_code == 200, 
                             msg=f"Expected HTTP 200, got {response.status_code}")
+            
+    @unittest.skipIf(not os.path.isdir('build_history'), 
+                     "Build history directory not found. Skipping test.")
+    def test_build_history_urls(self):
+        # Get all filenames in build_history
+        build_history_names = [f for f in os.listdir('build_history') 
+                               if os.path.isfile(os.path.join('build_history', f))]
+
+        with self.app.test_client() as client:
+            for name in build_history_names:
+                url = self.index_addr + "/build_history/" + name
+                response = client.get(url)
+                self.assertTrue(response.status_code == 200, 
+                                msg=f"Expected HTTP 200, got {response.status_code}")
     
     @classmethod
     def tearDownClass(cls) -> None:


### PR DESCRIPTION
Motivation: The grading guidelines state that one should be able to go through old builds to see their status and logs. This commit will add that functionality.

Resolves: #39