### PR TITLE
feat: add correct CI server url to commit status

### DIFF
--- a/ci_server/GitHub_API_functions.py
+++ b/ci_server/GitHub_API_functions.py
@@ -86,7 +86,7 @@ def create_commit_status(commit_hash, status):
 
   # Create commit status
   url_commit = f"https://api.github.com/repos/{OWNER}/{REPO}/statuses/{SHA}"
-  data = {"state":status,"target_url":"https://example.com/build/status","description":COMMIT_DESCRIPTION,"context":CONTEXT}
+  data = {"state":status,"target_url":"https://prompt-possum-first.ngrok-free.app/","description":COMMIT_DESCRIPTION,"context":CONTEXT}
 
   # Create and send POST request
   try:
@@ -101,8 +101,10 @@ def create_commit_status(commit_hash, status):
   returned_status_code = post_response.status_code
   if post_response.status_code == 201:
     returned_set_state   = post_response.json()["state"]
+    returned_target_url  = post_response.json()["target_url"]
   elif post_response.status_code != 201:
     returned_set_state   = post_response.json()["message"]
-  
-  return returned_status_code, returned_set_state
+    returned_target_url    = "Fail"
+
+  return returned_status_code, returned_set_state, returned_target_url
 

--- a/test_ci_server/test_GitHub_API_functions.py
+++ b/test_ci_server/test_GitHub_API_functions.py
@@ -8,7 +8,7 @@ class TestGitHubAPIFunctions(unittest.TestCase):
         # Commit hash corresponds to "Intial commit" in assignment 2 repository
         commit_hash = "00ba07dbe885385f308741a4bc70e1c866f2da7f"
         status = "success"
-        returned_status_code, returned_set_state = create_commit_status(commit_hash, status)
+        returned_status_code, returned_set_state, returned_target_url = create_commit_status(commit_hash, status)
         self.assertEqual(returned_status_code, 201) # Checks that the POST request was successful in updating commit status
         self.assertEqual(returned_set_state, status) # Check that the POST request set the right commit status
 
@@ -16,7 +16,7 @@ class TestGitHubAPIFunctions(unittest.TestCase):
         # Commit hash corresponds to "Intial commit" in assignment 2 repository
         commit_hash = "00ba07dbe885385f308741a4bc70e1c866f2da7f"
         status = "failure"
-        returned_status_code, returned_set_state = create_commit_status(commit_hash, status)
+        returned_status_code, returned_set_state, returned_target_url = create_commit_status(commit_hash, status)
         self.assertEqual(returned_status_code, 201) # Checks that the POST request was successful in updating commit status
         self.assertEqual(returned_set_state, status) # Check that the POST request set the right commit status
 
@@ -24,7 +24,7 @@ class TestGitHubAPIFunctions(unittest.TestCase):
         # Commit hash corresponds to "Intial commit" in assignment 2 repository
         commit_hash = "00ba07dbe885385f308741a4bc70e1c866f2da7f"
         status = "error"
-        returned_status_code, returned_set_state = create_commit_status(commit_hash, status)
+        returned_status_code, returned_set_state, returned_target_url = create_commit_status(commit_hash, status)
         self.assertEqual(returned_status_code, 201) # Checks that the POST request was successful in updating commit status
         self.assertEqual(returned_set_state, status) # Check that the POST request set the right commit status
     
@@ -32,7 +32,7 @@ class TestGitHubAPIFunctions(unittest.TestCase):
         # Commit hash corresponds to "Intial commit" in assignment 2 repository
         commit_hash = "00ba07dbe885385f308741a4bc70e1c866f2da7f"
         status = "pending"
-        returned_status_code, returned_set_state = create_commit_status(commit_hash, status)
+        returned_status_code, returned_set_state, returned_target_url = create_commit_status(commit_hash, status)
         self.assertEqual(returned_status_code, 201) # Checks that the POST request was successful in updating commit status
         self.assertEqual(returned_set_state, status) # Check that the POST request set the right commit status
     
@@ -40,10 +40,18 @@ class TestGitHubAPIFunctions(unittest.TestCase):
         commit_hash = "40"
         status = "pending"
         error_message = 'No commit found for SHA: 40'
-        returned_status_code, returned_set_state = create_commit_status(commit_hash, status)
+        returned_status_code, returned_set_state, returned_target_url = create_commit_status(commit_hash, status)
         self.assertEqual(returned_status_code, 422) # Checks that the POST request was not successful in updating commit status
         self.assertEqual(returned_set_state, error_message) # Check that the error message is as expected
+        self.assertEqual(returned_target_url,"Fail") # Checks that the echoed target url is as expected
 
+    def test_ngrok_server_github_connection(self):
+        # Commit hash corresponds to "Intial commit" in assignment 2 repository
+        commit_hash = "00ba07dbe885385f308741a4bc70e1c866f2da7f"
+        status = "success"
+        returned_status_code, returned_set_state, returned_target_url = create_commit_status(commit_hash, status)
+        self.assertEqual(returned_status_code, 201) # Checks that the POST request was successful in updating commit status
+        self.assertEqual(returned_target_url, "https://prompt-possum-first.ngrok-free.app/") # Checks that the echoed target url is as expected
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Adds the correct CI server url when setting the commit status. Used to be an example url that didn't go anywhere. Now the ngrok url is being used. When pressing on "details" of the commit status we are now redirected to the ngrok webpage. See Sebs initial commit.

Resolves #54