### PR TITLE
fix: server tests to use new hashing for authkey

### DIFF
--- a/ci_server/server.py
+++ b/ci_server/server.py
@@ -88,8 +88,6 @@ def webhook():
     if not authorized:
         log.error(f"Invalid secret key from {request.remote_addr}")
         return UNAUTHORIZED
-    # Make sure data is JSON
-    if not request.is_json: return BAD_REQUEST 
     
     # Try to get all the data needed
     try:
@@ -99,7 +97,8 @@ def webhook():
         timestamp     = datetime.fromisoformat(data['head_commit']['timestamp'])
         commit_author = data['head_commit']['author']
         pusher        = data['pusher']['name'] 
-    # All the above data is required, bad data otherwise
+    
+   # All the above data is required, bad data otherwise
     except KeyError as e:
         log.error(str(e))
         return BAD_REQUEST 

--- a/test_ci_server/test_server.py
+++ b/test_ci_server/test_server.py
@@ -39,7 +39,7 @@ class TestServer(unittest.TestCase):
         time.sleep(1)        
 
     def get_valid_authkey(self,payload): 
-      '''
+        '''
             Property returning the valid AUTHKEY
 
             Parameters


### PR DESCRIPTION
change valid_authkey to create a valid sha256 key for a given set of data

change server handler to try and decode json even though headers are not set

closes #52 